### PR TITLE
feat: add dark/light mode toggle with localStorage persistence

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -136,8 +136,36 @@ async function fetchContributors() {
   }
 }
 
+function initThemeToggle() {
+  const themeToggle = document.getElementById('themeToggle');
+  const themeIcon = document.getElementById('themeIcon');
+  const html = document.documentElement;
+
+  // Check for saved theme preference or default to 'dark'
+  const currentTheme = localStorage.getItem('theme') || 'dark';
+  html.setAttribute('data-theme', currentTheme);
+  updateThemeIcon(currentTheme);
+
+  // Toggle theme on button click
+  themeToggle?.addEventListener('click', () => {
+    const currentTheme = html.getAttribute('data-theme');
+    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+
+    html.setAttribute('data-theme', newTheme);
+    localStorage.setItem('theme', newTheme);
+    updateThemeIcon(newTheme);
+  });
+
+  function updateThemeIcon(theme) {
+    if (themeIcon) {
+      themeIcon.textContent = theme === 'dark' ? '☀️' : '🌙';
+    }
+  }
+}
+
 function boot() {
   fetchContributors();
+  initThemeToggle();
 }
 
 boot();

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -10,6 +10,16 @@
   --accent-2: #7df9d4;
   --danger: #ff6b6b;
 }
+
+[data-theme="light"] {
+  --bg: #f5f7fa;
+  --panel: #ffffff;
+  --text: #1a202c;
+  --muted: #4a5568;
+  --accent: #0088cc;
+  --accent-2: #00b894;
+  --danger: #e74c3c;
+}
 html,
 body {
   height: 100%;
@@ -28,6 +38,16 @@ body {
       800px 400px at 10% -10%,
       rgba(125, 249, 212, 0.12),
       transparent 50%
+    ),
+    var(--bg);
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+[data-theme="light"] body {
+  background: linear-gradient(
+      135deg,
+      rgba(107, 226, 255, 0.15) 0%,
+      rgba(125, 249, 212, 0.15) 100%
     ),
     var(--bg);
 }
@@ -84,6 +104,17 @@ a:visited {
   background: linear-gradient(135deg, var(--accent), var(--accent-2));
   color: #071220;
   font-weight: 700;
+}
+
+.theme-toggle {
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  font-size: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+[data-theme="light"] .theme-toggle {
+  border-color: rgba(0, 0, 0, 0.1);
 }
 
 main.container {
@@ -143,8 +174,9 @@ main.container {
   color: var(--muted);
   /* FIX 3: Ellipsis the description text after two lines */
   display: -webkit-box;
-  -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/index.html
+++ b/index.html
@@ -34,6 +34,9 @@
           <a class="btn primary" id="howToContribute" href="#contribute"
             >How to contribute</a
           >
+          <button id="themeToggle" class="btn theme-toggle" aria-label="Toggle theme">
+            <span id="themeIcon">☀️</span>
+          </button>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
Pull Request: Add Dark/Light Mode Toggle with Theme Persistence (#17)

This PR introduces a dark/light mode toggle to enhance the user experience, allowing seamless theme switching with persistent user preferences.

🔧 Implementation Details

Changes Made:

HTML:

Added a theme toggle button (☀️ / 🌙) in the header with ARIA labels for accessibility.

CSS:

Defined complete light theme variables (background, text, accent, danger colors).

Added transition effects for smooth theme switching.

JavaScript:

Implemented initThemeToggle() to manage theme switching.

Used localStorage to persist theme preference across sessions.

Updated toggle icon dynamically (☀️ for dark mode, 🌙 for light mode).

🌙☀️ Key Features

Default dark theme retained.

New light theme with eye-friendly, accessible color palette.

Theme persistence using localStorage.

Works seamlessly across devices and browsers.

Accessible with ARIA labels for screen readers.

🧪 Testing Checklist

 Toggle button visible in header.

 Smooth switching between dark and light themes.

 Good readability and contrast in light mode.

 Preference persists after refresh.

 Icon updates correctly (☀️ / 🌙).

 Tested across different browsers.

🎨 Design Notes

Light theme background: #f5f7fa.

Smooth gradients with radial + linear effects.

Subtle, modern minimalist design.

🔗 Related Issue

Closes #17 — Add dark/light mode toggle feature