### PR TITLE
📊 Add Contributor Statistics Page (#52)

### DIFF
--- a/assets/stats.js
+++ b/assets/stats.js
@@ -1,0 +1,553 @@
+async function fetchStats() {
+  try {
+    console.log("Fetching stats...");
+    const res = await fetch("./data/contributors.ndjson", {
+      cache: "no-store",
+    });
+    if (!res.ok) throw new Error("Network error");
+    const text = await res.text();
+    const lines = text
+      .split(/\n+/)
+      .map((l) => l.trim())
+      .filter(Boolean);
+    const contributors = lines
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+    
+    console.log(`Loaded ${contributors.length} contributors`);
+    console.log(contributors);
+
+    // Calculate all statistics
+    console.log("Calculating overview stats...");
+    calculateOverviewStats(contributors);
+    console.log("Calculating badge distribution...");
+    calculateBadgeDistribution(contributors);
+    console.log("Calculating growth over time...");
+    calculateGrowthOverTime(contributors);
+    console.log("Calculating name statistics...");
+    calculateNameStatistics(contributors);
+    console.log("Calculating fun facts...");
+    calculateFunFacts(contributors);
+    console.log("All statistics calculated!");
+  } catch (err) {
+    console.error("Error loading stats:", err);
+    document.querySelectorAll(".loading").forEach((el) => {
+      el.textContent = "Could not load statistics. Please refresh and try again.";
+      el.classList.add("error");
+    });
+    console.error("Stats loading failed. Check the error message above for details.");
+  }
+}
+
+function calculateOverviewStats(contributors) {
+  try {
+    console.log("Calculating overview stats...");
+    // Total contributors
+    const totalEl = document.getElementById("totalContributors");
+    if (totalEl) totalEl.textContent = contributors.length;
+
+  // Newest contributor
+  const sortedByNewest = [...contributors].sort(
+    (a, b) => (b.addedAt || "").localeCompare(a.addedAt || "")
+  );
+  const newest = sortedByNewest[0];
+  const newestEl = document.getElementById("newestContributor");
+  if (newestEl) {
+    newestEl.textContent = newest
+      ? newest.name || newest.username || "Unknown"
+      : "-";
+  }
+
+  // First contributor
+  const sortedByOldest = [...contributors].sort(
+    (a, b) => (a.addedAt || "").localeCompare(b.addedAt || "")
+  );
+  const first = sortedByOldest[0];
+  const firstEl = document.getElementById("firstContributor");
+  if (firstEl) {
+    firstEl.textContent = first
+      ? first.name || first.username || "Unknown"
+      : "-";
+  }
+
+  // Average per month
+  if (contributors.length > 0) {
+    const dates = contributors
+      .map((c) => new Date(c.addedAt))
+      .filter((d) => !isNaN(d.getTime()))
+      .sort((a, b) => a - b);
+
+    if (dates.length > 0) {
+      const firstDate = dates[0];
+      const lastDate = dates[dates.length - 1];
+      const monthsDiff =
+        (lastDate.getFullYear() - firstDate.getFullYear()) * 12 +
+        (lastDate.getMonth() - firstDate.getMonth()) +
+        1;
+      const avgPerMonth = Math.round(contributors.length / monthsDiff);
+      const avgEl = document.getElementById("avgPerMonth");
+      if (avgEl) avgEl.textContent = avgPerMonth;
+    }
+  }
+  } catch (err) {
+    console.error("Error calculating overview stats:", err);
+  }
+}
+
+function calculateBadgeDistribution(contributors) {
+  try {
+    console.log("Calculating badge distribution...");
+    const badgeContainer = document.getElementById("badgeDistribution");
+    if (!badgeContainer) {
+      console.error("Badge distribution container not found");
+      return;
+    }
+    badgeContainer.innerHTML = "";
+
+  // Count badges
+  const badgeCounts = {};
+  contributors.forEach((contributor) => {
+    if (contributor.badges && Array.isArray(contributor.badges)) {
+      contributor.badges.forEach((badge) => {
+        const badgeType = typeof badge === "string" ? badge : badge.type;
+        badgeCounts[badgeType] = (badgeCounts[badgeType] || 0) + 1;
+      });
+    }
+  });
+
+  // Get badge icons
+  const badgeIcons = {
+    first: { icon: "🥇", label: "First" },
+    core: { icon: "⭐", label: "Core Team" },
+    top: { icon: "🏆", label: "Top Contributor" },
+    helper: { icon: "🤝", label: "Helper" },
+    early: { icon: "🌱", label: "Early Adopter" },
+    milestone: { icon: "🎯", label: "Milestone" },
+  };
+
+  // Create badge distribution elements
+  const total = contributors.length;
+  Object.entries(badgeCounts).forEach(([badge, count]) => {
+    const percentage = Math.round((count / total) * 100);
+    const badgeInfo = badgeIcons[badge] || { icon: "🏅", label: badge };
+
+    const badgeEl = document.createElement("div");
+    badgeEl.className = "badge-stat-item";
+    badgeEl.innerHTML = `
+      <div class="badge-info">
+        <span class="badge-icon">${badgeInfo.icon}</span>
+        <span class="badge-name">${badgeInfo.label}</span>
+        <span class="badge-count">${count} (${percentage}%)</span>
+      </div>
+      <div class="badge-bar">
+        <div class="badge-bar-fill" style="width: ${percentage}%"></div>
+      </div>
+    `;
+    badgeContainer.appendChild(badgeEl);
+  });
+
+  if (Object.keys(badgeCounts).length === 0) {
+    badgeContainer.innerHTML = "<p>No badges have been awarded yet.</p>";
+  }
+  } catch (err) {
+    console.error("Error calculating badge distribution:", err);
+    const badgeContainer = document.getElementById("badgeDistribution");
+    if (badgeContainer) {
+      badgeContainer.innerHTML = "<p>Could not load badge statistics. Please refresh and try again.</p>";
+    }
+  }
+}
+
+function calculateGrowthOverTime(contributors) {
+  try {
+    console.log("Calculating growth over time...");
+    const growthContainer = document.getElementById("growthChart");
+    if (!growthContainer) {
+      console.error("Growth chart container not found");
+      return;
+    }
+    growthContainer.innerHTML = "";
+
+  // Group by month
+  const monthlyCounts = {};
+  let cumulativeCount = 0;
+
+  // Process all months in chronological order
+  contributors.forEach((contributor) => {
+    if (contributor.addedAt) {
+      const date = new Date(contributor.addedAt);
+      if (!isNaN(date.getTime())) {
+        const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+        if (!monthlyCounts[monthKey]) {
+          monthlyCounts[monthKey] = 0;
+        }
+        monthlyCounts[monthKey]++;
+      }
+    }
+  });
+
+  // Sort months chronologically
+  const sortedMonths = Object.keys(monthlyCounts).sort();
+
+  // Calculate cumulative values
+  const cumulativeData = {};
+  sortedMonths.forEach((month) => {
+    cumulativeCount += monthlyCounts[month];
+    cumulativeData[month] = cumulativeCount;
+  });
+
+  // Find max count for scaling
+  const maxCount = Math.max(...Object.values(cumulativeData), 1);
+
+  // Create chart
+  const chartEl = document.createElement("div");
+  chartEl.className = "bar-chart";
+
+  sortedMonths.forEach((month) => {
+    const count = cumulativeData[month];
+    // Ensure minimum height for visibility and proper scaling
+    const percentage = Math.max(5, (count / maxCount) * 100);
+
+    const [year, monthNum] = month.split("-");
+    const monthName = new Date(year, monthNum - 1).toLocaleDateString("en-US", {
+      month: "short",
+      year: "numeric"
+    });
+
+    const barEl = document.createElement("div");
+    barEl.className = "bar-item";
+    barEl.innerHTML = `
+      <div class="bar-container">
+        <div class="bar" style="height: ${percentage}%"></div>
+      </div>
+      <div class="bar-label">${monthName}</div>
+      <div class="bar-value">${count}</div>
+    `;
+    chartEl.appendChild(barEl);
+  });
+
+  growthContainer.appendChild(chartEl);
+
+  if (sortedMonths.length === 0) {
+    growthContainer.innerHTML = "<p>No growth data available.</p>";
+  }
+  } catch (err) {
+    console.error("Error calculating growth over time:", err);
+    const growthContainer = document.getElementById("growthChart");
+    if (growthContainer) {
+      growthContainer.innerHTML = "<p>Could not load growth statistics. Please refresh and try again.</p>";
+    }
+  }
+}
+
+function calculateNameStatistics(contributors) {
+  try {
+    console.log("Calculating name statistics...");
+    const nameContainer = document.getElementById("nameStatistics");
+    if (!nameContainer) {
+      console.error("Name statistics container not found");
+      return;
+    }
+    nameContainer.innerHTML = "";
+
+  // Extract first names
+  const firstNames = {};
+  contributors.forEach((contributor) => {
+    if (contributor.name) {
+      const firstName = contributor.name.split(" ")[0];
+      firstNames[firstName] = (firstNames[firstName] || 0) + 1;
+    }
+  });
+
+  // Find most common name
+  const sortedNames = Object.entries(firstNames).sort((a, b) => b[1] - a[1]);
+  const mostCommon = sortedNames[0];
+
+  // Find longest and shortest names
+  const nameLengths = contributors
+    .filter((c) => c.name)
+    .map((c) => ({ name: c.name, length: c.name.length }))
+    .sort((a, b) => b.length - a.length);
+
+  const longestName = nameLengths[0];
+  const shortestName = nameLengths[nameLengths.length - 1];
+
+  // Create name statistics elements
+  const statsEl = document.createElement("div");
+  statsEl.className = "name-stats";
+
+  if (mostCommon) {
+    const mostCommonEl = document.createElement("div");
+    mostCommonEl.className = "name-stat-item";
+    mostCommonEl.innerHTML = `
+      <div class="name-stat-label">Most common name</div>
+      <div class="name-stat-value">${mostCommon[0]} (${mostCommon[1]} contributors)</div>
+    `;
+    statsEl.appendChild(mostCommonEl);
+  }
+
+  if (longestName) {
+    const longestEl = document.createElement("div");
+    longestEl.className = "name-stat-item";
+    longestEl.innerHTML = `
+      <div class="name-stat-label">Longest name</div>
+      <div class="name-stat-value">${longestName.name} (${longestName.length} characters)</div>
+    `;
+    statsEl.appendChild(longestEl);
+  }
+
+  if (shortestName) {
+    const shortestEl = document.createElement("div");
+    shortestEl.className = "name-stat-item";
+    shortestEl.innerHTML = `
+      <div class="name-stat-label">Shortest name</div>
+      <div class="name-stat-value">${shortestName.name} (${shortestName.length} characters)</div>
+    `;
+    statsEl.appendChild(shortestEl);
+  }
+
+  nameContainer.appendChild(statsEl);
+
+  if (sortedNames.length === 0) {
+    nameContainer.innerHTML = "<p>No name data available.</p>";
+  }
+  } catch (err) {
+    console.error("Error calculating name statistics:", err);
+    const nameContainer = document.getElementById("nameStatistics");
+    if (nameContainer) {
+      nameContainer.innerHTML = "<p>Could not load name statistics. Please refresh and try again.</p>";
+    }
+  }
+}
+
+function calculateFunFacts(contributors) {
+  try {
+    console.log("Calculating fun facts...");
+    const factsContainer = document.getElementById("funFacts");
+    if (!factsContainer) {
+      console.error("Fun facts container not found");
+      return;
+    }
+    factsContainer.innerHTML = "";
+
+  const facts = [];
+
+  // First contributor fact
+  const sortedByOldest = [...contributors].sort(
+    (a, b) => (a.addedAt || "").localeCompare(b.addedAt || "")
+  );
+  const first = sortedByOldest[0];
+  if (first) {
+    const date = new Date(first.addedAt);
+    if (!isNaN(date.getTime())) {
+      facts.push(
+        `The first contributor was ${first.name || first.username || "Unknown"}, who joined on ${date.toLocaleDateString("en-US", {
+          year: "numeric",
+          month: "long",
+          day: "numeric"
+        })}`
+      );
+    }
+  }
+
+  // Busiest month fact
+  const monthlyCounts = {};
+  contributors.forEach((contributor) => {
+    if (contributor.addedAt) {
+      const date = new Date(contributor.addedAt);
+      if (!isNaN(date.getTime())) {
+        const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+        monthlyCounts[monthKey] = (monthlyCounts[monthKey] || 0) + 1;
+      }
+    }
+  });
+
+  const sortedMonths = Object.entries(monthlyCounts).sort((a, b) => b[1] - a[1]);
+  if (sortedMonths.length > 0) {
+    const [month, count] = sortedMonths[0];
+    const [year, monthNum] = month.split("-");
+    const monthName = new Date(year, monthNum - 1).toLocaleDateString("en-US", {
+      month: "long",
+      year: "numeric"
+    });
+    facts.push(`${monthName} was our busiest month with ${count} new contributors`);
+  }
+
+  // Most common name fact
+  const firstNames = {};
+  contributors.forEach((contributor) => {
+    if (contributor.name) {
+      const firstName = contributor.name.split(" ")[0];
+      firstNames[firstName] = (firstNames[firstName] || 0) + 1;
+    }
+  });
+
+  const sortedNames = Object.entries(firstNames).sort((a, b) => b[1] - a[1]);
+  if (sortedNames.length > 0) {
+    const [name, count] = sortedNames[0];
+    facts.push(`The most common first name is "${name}" (appears ${count} time${count > 1 ? "s" : ""})`);
+  }
+
+  // Badge percentage fact
+  const contributorsWithBadges = contributors.filter(
+    (c) => c.badges && Array.isArray(c.badges) && c.badges.length > 0
+  ).length;
+
+  if (contributors.length > 0) {
+    const badgePercentage = Math.round((contributorsWithBadges / contributors.length) * 100);
+    facts.push(`${badgePercentage}% of contributors have at least one badge`);
+  }
+
+  // Longest message fact
+  const messages = contributors
+    .filter((c) => c.message)
+    .map((c) => ({ name: c.name || c.username, message: c.message, length: c.message.length }))
+    .sort((a, b) => b.length - a.length);
+
+  if (messages.length > 0) {
+    const longest = messages[0];
+    facts.push(`The longest message is ${longest.length} characters long by ${longest.name}`);
+  }
+
+  // Average per week fact
+  if (contributors.length > 0) {
+    const dates = contributors
+      .map((c) => new Date(c.addedAt))
+      .filter((d) => !isNaN(d.getTime()))
+      .sort((a, b) => a - b);
+
+    if (dates.length > 0) {
+      const firstDate = dates[0];
+      const lastDate = dates[dates.length - 1];
+      const weeksDiff = Math.max(1, Math.ceil((lastDate - firstDate) / (7 * 24 * 60 * 60 * 1000)));
+      const avgPerWeek = Math.round(contributors.length / weeksDiff);
+      facts.push(`Average of ${avgPerWeek} contributor${avgPerWeek === 1 ? "" : "s"} per week`);
+    }
+  }
+
+  // Create fun facts list
+  const factsListEl = document.createElement("ul");
+  factsListEl.className = "fun-facts-list";
+
+  facts.forEach((fact) => {
+    const factEl = document.createElement("li");
+    factEl.textContent = fact;
+    factsListEl.appendChild(factEl);
+  });
+
+  factsContainer.appendChild(factsListEl);
+
+  if (facts.length === 0) {
+    factsContainer.innerHTML = "<p>No fun facts available yet.</p>";
+  }
+  } catch (err) {
+    console.error("Error calculating fun facts:", err);
+    const factsContainer = document.getElementById("funFacts");
+    if (factsContainer) {
+      factsContainer.innerHTML = "<p>Could not load fun facts. Please refresh and try again.</p>";
+    }
+  }
+}
+
+function initThemeToggle() {
+  const themeToggle = document.getElementById("themeToggle");
+  const themeIcon = document.getElementById("themeIcon");
+  const html = document.documentElement;
+
+  // Check for saved theme preference or default to 'dark'
+  const currentTheme = localStorage.getItem("theme") || "dark";
+  html.setAttribute("data-theme", currentTheme);
+  updateThemeIcon(currentTheme);
+
+  // Toggle theme on button click
+  themeToggle?.addEventListener("click", () => {
+    const currentTheme = html.getAttribute("data-theme");
+    const newTheme = currentTheme === "dark" ? "light" : "dark";
+
+    html.setAttribute("data-theme", newTheme);
+    localStorage.setItem("theme", newTheme);
+    updateThemeIcon(newTheme);
+  });
+
+  function updateThemeIcon(theme) {
+    if (themeIcon) {
+      themeIcon.textContent = theme === "dark" ? "☀️" : "🌙";
+    }
+  }
+}
+
+function initScrollToTop() {
+  const scrollButton = document.getElementById("scrollToTop");
+  if (!scrollButton) return;
+
+  // Create a sentinel element at the top
+  const sentinel = document.createElement("div");
+  sentinel.style.position = "absolute";
+  sentinel.style.top = "200px";
+  sentinel.style.height = "1px";
+  document.body.insertBefore(sentinel, document.body.firstChild);
+
+  // Observe when we scroll past the sentinel
+  const observer = new IntersectionObserver(
+    ([entry]) => {
+      if (entry.isIntersecting) {
+        scrollButton.classList.remove("visible");
+      } else {
+        scrollButton.classList.add("visible");
+      }
+    },
+    { threshold: 0 }
+  );
+
+  observer.observe(sentinel);
+
+  scrollButton.addEventListener("click", () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  });
+}
+
+function initScrollProgress() {
+  const progressBar = document.getElementById("scrollProgress");
+  if (!progressBar) return;
+
+  function updateProgress() {
+    const scrollTop = window.scrollY;
+    const docHeight =
+      document.documentElement.scrollHeight - window.innerHeight;
+    // Prevent division by zero
+    if (docHeight <= 0) {
+      progressBar.style.width = "0%";
+      return;
+    }
+    const scrollPercent = Math.min(100, Math.max(0, (scrollTop / docHeight) * 100));
+    progressBar.style.width = `${scrollPercent}%`;
+  }
+
+  window.addEventListener("scroll", updateProgress);
+  updateProgress(); // initialize on load
+}
+
+function boot() {
+  fetchStats();
+  initThemeToggle();
+  initScrollToTop();
+  initScrollProgress();
+}
+
+// Initialize when DOM is ready
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", boot);
+} else {
+  boot();
+}
+
+boot();

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1190,9 +1190,9 @@ main.container {
 /* Stats cards */
 .stats-cards {
   display: flex;
-  gap: 1rem;
+  gap: 0.8rem;
   flex-wrap: wrap;
-  margin-top: 1rem;
+  margin-top: 0.8rem;
 }
 
 /* Badge filters */
@@ -1267,31 +1267,36 @@ main.container {
 }
 
 .stat-card {
-  flex: 1 1 200px;
-  background: var(--panel);
-  border-radius: 16px;
-  padding: 1.25rem 1rem;
+  flex: 1 1 180px;
+  background: linear-gradient(
+    145deg,
+    rgba(255, 255, 255, 0.04),
+    rgba(255, 255, 255, 0.01)
+  );
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 1rem;
   text-align: center;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.08);
-  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.06);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .stat-card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+  transform: translateY(-2px);
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
 }
 
 .stat-value {
-  font-size: 1.7rem;
-  font-weight: 800;
+  font-size: 1.5rem;
+  font-weight: 700;
   color: var(--accent-2);
 }
 
 .stat-label {
-  font-size: 0.85rem;
-  font-weight: 600;
+  font-size: 0.8rem;
+  font-weight: 500;
   color: var(--muted);
-  margin-top: 0.25rem;
+  margin-top: 0.2rem;
 }
 
 /* --- HOW TO CONTRIBUTE --- */
@@ -1427,5 +1432,425 @@ main.container {
     text-align: center;
     margin-left: 0;
     margin-top: 0.25rem;
+  }
+}
+
+/* --- STATS PAGE STYLES --- */
+.stats-section {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.stats-card {
+  background: linear-gradient(
+    145deg,
+    rgba(255, 255, 255, 0.04),
+    rgba(255, 255, 255, 0.01)
+  );
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 1.25rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.stats-card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+}
+
+.stats-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
+}
+
+.stats-card h3 {
+  margin: 0 0 1rem;
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--accent-2);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+/* Badge Distribution Styles */
+.badge-distribution {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.badge-stat-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.8rem;
+  background: linear-gradient(
+    145deg,
+    rgba(255, 255, 255, 0.07),
+    rgba(255, 255, 255, 0.03)
+  );
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.badge-stat-item::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 2px;
+  height: 100%;
+  background: linear-gradient(180deg, var(--accent), var(--accent-2));
+  opacity: 0.6;
+}
+
+.badge-stat-item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  background: linear-gradient(
+    145deg,
+    rgba(255, 255, 255, 0.09),
+    rgba(255, 255, 255, 0.04)
+  );
+}
+
+.badge-info {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.badge-icon {
+  font-size: 1.2rem;
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.15));
+  padding: 0.3rem;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.badge-name {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--text);
+}
+
+.badge-count {
+  margin-left: auto;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--accent-2);
+  background: rgba(107, 226, 255, 0.12);
+  padding: 0.2rem 0.5rem;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(107, 226, 255, 0.15);
+  min-width: 28px;
+  text-align: center;
+}
+
+.badge-bar {
+  height: 4px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 2px;
+  overflow: hidden;
+  position: relative;
+  margin-top: 0.2rem;
+}
+
+.badge-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+  border-radius: 2px;
+  transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  box-shadow: 0 0 4px rgba(107, 226, 255, 0.2);
+}
+
+.badge-bar-fill::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.3),
+    transparent
+  );
+  animation: shimmer 2s infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+/* Growth Chart Styles */
+.growth-chart {
+  width: 100%;
+  padding: 0.75rem;
+  background: rgba(255, 255, 255, 0.015);
+  border-radius: 8px;
+}
+
+.bar-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.6rem;
+  height: 200px;
+  padding: 0.75rem 0.6rem 1.5rem;
+  overflow-x: auto;
+  position: relative;
+  width: 100%;
+}
+
+.bar-chart::before {
+  content: "";
+  position: absolute;
+  bottom: 0.6rem;
+  left: 0.6rem;
+  right: 0.6rem;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.bar-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  min-width: 50px;
+  position: relative;
+  flex: 1;
+  max-width: 80px;
+}
+
+.bar-container {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: flex-end;
+  position: relative;
+  flex-grow: 1;
+}
+
+.bar {
+  width: 100%;
+  background: linear-gradient(180deg, var(--accent), var(--accent-2));
+  border-radius: 3px 3px 0 0;
+  transition: height 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  box-shadow: 0 0 8px rgba(107, 226, 255, 0.2);
+  min-height: 5px;
+}
+
+.bar::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.3);
+  border-radius: 3px 3px 0 0;
+}
+
+.bar-label {
+  font-size: 0.7rem;
+  color: var(--muted);
+  text-align: center;
+  font-weight: 500;
+  margin-top: 0.2rem;
+}
+
+.bar-value {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent-2);
+  background: rgba(107, 226, 255, 0.08);
+  padding: 0.1rem 0.25rem;
+  border-radius: 3px;
+  min-width: 20px;
+  text-align: center;
+}
+
+/* Name Statistics Styles */
+.name-statistics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.name-stat-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-left: 0.5rem;
+  padding: 0.5rem 0.8rem;
+  background: rgba(107, 226, 255, 0.08);
+  border: 1px solid rgba(107, 226, 255, 0.15);
+  border-radius: 20px;
+  transition: all 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.name-stat-item:hover {
+  background: rgba(107, 226, 255, 0.12);
+  border-color: rgba(107, 226, 255, 0.25);
+  transform: scale(1.02);
+}
+
+.name-stat-label {
+  font-size: 0.7rem;
+  color: var(--muted);
+  font-weight: 500;
+  opacity: 0.85;
+}
+
+.name-stat-value {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--accent-2);
+  white-space: nowrap;
+}
+
+/* Add icon before each stat item */
+.name-stat-item::before {
+  content: "👤";
+  font-size: 0.8rem;
+  opacity: 0.7;
+}
+
+/* Fun Facts Styles */
+.fun-facts-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5rem;
+}
+
+.fun-facts-list li {
+  padding: 1.5rem;
+  background: linear-gradient(
+    145deg,
+    rgba(255, 255, 255, 0.05),
+    rgba(255, 255, 255, 0.02)
+  );
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  position: relative;
+  padding-left: 3.5rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.fun-facts-list li:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
+  background: linear-gradient(
+    145deg,
+    rgba(255, 255, 255, 0.08),
+    rgba(255, 255, 255, 0.03)
+  );
+}
+
+.fun-facts-list li::before {
+  content: "✨";
+  position: absolute;
+  left: 1.5rem;
+  top: 1.5rem;
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+/* Mobile Responsiveness for Stats */
+@media (max-width: 768px) {
+  .stats-section {
+    gap: 2rem;
+  }
+
+  .stats-card {
+    padding: 1.5rem;
+  }
+
+  .stats-card h3 {
+    font-size: 1.5rem;
+  }
+
+  .badge-distribution {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .badge-stat-item {
+    padding: 1rem;
+  }
+
+  .badge-icon {
+    width: 45px;
+    height: 45px;
+    font-size: 1.4rem;
+  }
+
+  .bar-chart {
+    height: 200px;
+    gap: 1rem;
+    padding: 1rem 0.5rem 0.5rem;
+  }
+
+  .bar-item {
+    min-width: 60px;
+  }
+
+  .name-statistics {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .name-stat-item {
+    padding: 1rem;
+  }
+
+  .fun-facts-list {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .fun-facts-list li {
+    padding: 1rem 1rem 1rem 2.5rem;
+  }
+
+  .fun-facts-list li::before {
+    left: 1rem;
+    top: 1rem;
   }
 }

--- a/index.html
+++ b/index.html
@@ -34,6 +34,9 @@
           <a class="btn" id="repoLink" target="_blank" rel="noopener"
             >View Repo</a
           >
+          <a class="btn" href="stats.html"
+            >📊 Stats</a
+          >
           <a class="btn primary" id="howToContribute" href="#contribute"
             >How to contribute</a
           >

--- a/stats.html
+++ b/stats.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>FirstLeaf — Statistics</title>
+    <meta
+      name="description"
+      content="Contributor statistics and analytics for the FirstLeaf project."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./assets/styles.css" />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>🩵</text></svg>"
+    />
+  </head>
+  <body>
+    <div id="scrollProgress"></div>
+    <header class="site-header">
+      <div class="container header-wrapper">
+        <div class="branding">
+          <h1 class="logo">FirstLeaf</h1>
+          <p class="tagline">
+            Contributor Statistics and Analytics
+          </p>
+        </div>
+        <nav class="actions">
+          <a class="btn" href="index.html">← Back to Contributors</a>
+          <button
+            id="themeToggle"
+            class="btn theme-toggle"
+            aria-label="Toggle theme"
+          >
+            <span id="themeIcon">☀️</span>
+          </button>
+        </nav>
+      </div>
+    </header>
+
+    <main class="container">
+      <!-- Stats Overview Section -->
+      <section aria-labelledby="stats-title" class="stats-section">
+        <div class="section-header">
+          <div class="title-group">
+            <h2 id="stats-title">📊 Contributor Statistics</h2>
+          </div>
+        </div>
+
+        <!-- Overview Stats Cards -->
+        <div class="stats-cards">
+          <div class="stat-card">
+            <div class="stat-value" id="totalContributors">0</div>
+            <div class="stat-label">Total Contributors</div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-value" id="newestContributor">-</div>
+            <div class="stat-label">Newest Contributor</div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-value" id="firstContributor">-</div>
+            <div class="stat-label">First Contributor</div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-value" id="avgPerMonth">0</div>
+            <div class="stat-label">Avg. Per Month</div>
+          </div>
+        </div>
+
+        <!-- Badge Distribution -->
+        <div class="stats-card">
+          <h3>🏷️ Badge Distribution</h3>
+          <div id="badgeDistribution" class="badge-distribution">
+            <div class="loading">Loading statistics...</div>
+          </div>
+        </div>
+
+        <!-- Growth Over Time -->
+        <div class="stats-card">
+          <h3>📈 Growth Over Time</h3>
+          <div id="growthChart" class="growth-chart">
+            <div class="loading">Loading statistics...</div>
+          </div>
+        </div>
+
+        <!-- Name Statistics -->
+        <div class="stats-card">
+          <h3>👤 Name Statistics</h3>
+          <div id="nameStatistics" class="name-statistics">
+            <div class="loading">Loading statistics...</div>
+          </div>
+        </div>
+
+        <!-- Fun Facts -->
+        <div class="stats-card">
+          <h3>🎯 Fun Facts & Trivia</h3>
+          <div id="funFacts" class="fun-facts">
+            <div class="loading">Loading statistics...</div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>Built with 💙 for first‑time contributors by Jadu</p>
+      </div>
+    </footer>
+
+    <script src="./assets/stats.js"></script>
+    <button
+      id="scrollToTop"
+      class="scroll-to-top"
+      aria-label="Scroll to top"
+      title="Back to top"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <polyline points="18 15 12 9 6 15"></polyline>
+      </svg>
+    </button>
+  </body>
+</html>


### PR DESCRIPTION
### Description
Implemented the new **Stats** page showing contributor analytics and fun insights.  
Includes total contributors, badge distribution, name trends, growth charts, and fun facts.

Fixes #52 

### Features
- 📈 Contributor growth over time  
- 🏷️ Badge distribution charts  
- 👤 Name and join stats  
- 🎯 Fun facts & trivia  
- 🔗 “Stats” link in navigation  
- 📱 Fully responsive design  

### Screenshots
<img width="2286" height="3022" alt="127 0 0 1_5500_FirstLeaf_stats html" src="https://github.com/user-attachments/assets/5552c9ce-e178-4161-81ea-ed38575b2584" />


### Testing
- [x] Stats page loads correctly  
- [x] Charts render properly  
- [x] Data calculates accurately  
- [x] Navigation and back button work  
- [x] No console errors  

### Linked Issue
Closes #52
